### PR TITLE
Fix version check failure because of non-SSL link

### DIFF
--- a/src/net/azib/ipscan/config/Version.java
+++ b/src/net/azib/ipscan/config/Version.java
@@ -17,7 +17,7 @@ public class Version {
 	
 	public static final String COPYLEFT = "© 2017 Anton Keks and contributors";
 	
-	public static final String WEBSITE = "http://angryip.org";
+	public static final String WEBSITE = "https://angryip.org";
 	
 	public static final String FAQ_URL = WEBSITE + "/faq/";
 


### PR DESCRIPTION
Update to the new SSL URI for the website to allow the version update check routine to run properly.

Fixes #142