### PR TITLE
missing sed -r option on OSX

### DIFF
--- a/update-mac-vendors.sh
+++ b/update-mac-vendors.sh
@@ -1,9 +1,18 @@
 #!/bin/bash
 # This scripts downloads and optimizes IEEE MAC vendor list
+#
+# FILE: update-mac-vendors.sh
+# Mac users: Install Gnu-Sed via brew install gnu-sed then change sed into gsed (why? Option -r did not exist on OSX)(cheers Zwilla)
+
+SED_APP='sed'
+if [ "$(uname)" = "Darwin" ]; then
+  brew install gnu-sed;
+  SED_APP='gsed';
+fi
 
 curl 'http://standards-oui.ieee.org/oui.txt' |\
 #cat oui.txt |\
-fgrep '(base 16)' | sed -r '
+fgrep '(base 16)' | $SED_APP -r '
 	s/\r//g; s/     \(base 16\)\t\t//
 	s/,? ?(Inc)\.?$//I
 	s/(,|, | )(Ltd|Limited|GmbH|LLC|A\/S|AB|AS|SAS|AG|KG|PLC|SRL|OY|Oy|BV|Nederland BV|SAN VE TIC)\.?$//Ig


### PR DESCRIPTION
MAC Users: Install Gnu-Sed via brew install gnu-sed then change sed into gsed.
This small function installs auto gnu-sed and makes use of it only at Darwin.
Tested and works.

Output:
  ```
% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current Dload  Upload   Total   Spent    Left  Speed
100 4127k  100 4127k    0     0   448k      0  0:00:09  0:00:09 --:--:--  475k
   26774 resources/mac-vendors.txt
```