### PR TITLE
Add macOS aarch64 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,12 @@ plugins {
 
 def osName = System.getProperty("os.name")
 def is64 = System.getProperty("os.arch").contains("64")
+def isArm = System.getProperty("os.arch").equals("aarch64")
 def platform = osName.contains("Linux") ? 'linux' + (is64 ? '64' : '32') :
                osName.contains("Windows") ? 'win' + (is64 ? '64' : '32') :
-               osName.contains("OS X") ? 'mac' : 'unknown'
+               osName.contains("OS X") ? 'mac' + (isArm ? "Arm64" : "X86") : 'unknown'
+
+println(System.getProperty("java.home"))
 
 version = gitVersion()
 sourceCompatibility = 1.8
@@ -43,7 +46,8 @@ configurations {
     linux64
     win32.extendsFrom(jna)
     win64.extendsFrom(jna)
-    mac
+    macX86
+    macArm64
 
     // compile and test with current platform's SWT and JNA
     compileOnly.extendsFrom(getAt(platform), jna)
@@ -53,11 +57,12 @@ configurations {
 }
 
 dependencies {
-    def swtVersion = '3.115.100'
+    def swtVersion = '3.117.0'
     linux64 "org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:${swtVersion}"
     win64 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:${swtVersion}"
-    win32 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86:3.108.0"
-    mac "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:${swtVersion}"
+    win32 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86:${swtVersion}"
+    macX86 "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:${swtVersion}"
+    macArm64 "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:${swtVersion}"
     jna "net.java.dev.jna:jna:5.6.0"
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.23.0'
@@ -216,31 +221,14 @@ def rpm(def platform, def arch) {
     ant.delete(dir: dist)
 }
 
-packageTask('linux64', 'ext/rocksaw/lib/linux64/librocksaw.so') {
-    deb('linux64', 'amd64')
-    rpm('linux64', 'x86_64')
-}
-
-packageTask('any') {
-    deb('any', 'all', 'libswt-gtk-4-java, libswt-cairo-gtk-4-jni,')
-}
-
-packageTask('win32', 'ext/rocksaw/lib/rocksaw.dll') {
-    winLauncher('win32')
-}
-
-packageTask('win64') {
-    winLauncher('win64')
-}
-
-packageTask('mac') {
+def macLauncher(def platform) {
     def dist = buildDir.path + '/libs'
     def name = 'Angry IP Scanner'
     ant.copy(todir: dist) {
         ant.fileset(dir: "ext/mac-bundle")
     }
 
-    ant.copy(file: "${dist}/${project.name}-mac-${version}.jar", todir: "${dist}/${name}.app/Contents/MacOS")
+    ant.copy(file: "${dist}/${project.name}-${platform}-${version}.jar", todir: "${dist}/${name}.app/Contents/MacOS")
 
     ant.replace(file: "${dist}/${name}.app/Contents/Info.plist") {
         ant.replacefilter(token: "APPNAME", value: name)
@@ -248,8 +236,8 @@ packageTask('mac') {
         ant.replacefilter(token: "VERSION", value: version)
     }
 
-    def zipName = "${dist}/${project.name}-mac-${version}.zip"
-    ant.zip(destfile: "${dist}/${project.name}-mac-${version}.zip") {
+    def zipName = "${dist}/${project.name}-${platform}-${version}.zip"
+    ant.zip(destfile: "${dist}/${project.name}-${platform}-${version}.zip") {
         ant.zipfileset(dir: "${dist}/${name}.app", excludes: "Contents/MacOS/ipscan", prefix: "${name}.app")
         // this one should be executable
         ant.zipfileset(dir: "${dist}/${name}.app", includes: "Contents/MacOS/ipscan", prefix: "${name}.app", filemode: "755")
@@ -271,18 +259,43 @@ packageTask('mac') {
             ant.arg(value: "altool")
             ant.arg(value: "--notarize-app")
             ant.arg(value: "--primary-bundle-id")
-                ant.arg(value: "net.azib.ipscan.zip")
+            ant.arg(value: "net.azib.ipscan.zip")
             ant.arg(value: "--username")
-                ant.arg(value: System.getenv("APPLE_USER"))
+            ant.arg(value: System.getenv("APPLE_USER"))
             ant.arg(value: "--password")
-                ant.arg(value: System.getenv("APPLE_PASSWORD"))
+            ant.arg(value: System.getenv("APPLE_PASSWORD"))
             ant.arg(value: "--file")
-                ant.arg(value: zipName)
+            ant.arg(value: zipName)
         }
     }
 
     ant.delete(dir: "${dist}/${name}.app")
-    ant.delete(file: "${dist}/${project.name}-mac-${version}.jar")
+    ant.delete(file: "${dist}/${project.name}-${platform}-${version}.jar")
+}
+
+packageTask('linux64', 'ext/rocksaw/lib/linux64/librocksaw.so') {
+    deb('linux64', 'amd64')
+    rpm('linux64', 'x86_64')
+}
+
+packageTask('any') {
+    deb('any', 'all', 'libswt-gtk-4-java, libswt-cairo-gtk-4-jni,')
+}
+
+packageTask('win32', 'ext/rocksaw/lib/rocksaw.dll') {
+    winLauncher('win32')
+}
+
+packageTask('win64') {
+    winLauncher('win64')
+}
+
+packageTask('macX86') {
+    macLauncher("macX86")
+}
+
+packageTask('macArm64') {
+    macLauncher("macArm64")
 }
 
 task 'win-installer'(dependsOn: ['win32', 'win64']) {
@@ -314,7 +327,7 @@ task 'win-installer'(dependsOn: ['win32', 'win64']) {
     }
 }
 
-task all(dependsOn: ['any', 'linux64', 'mac', 'win-installer'])
+task all(dependsOn: ['any', 'linux64', 'macX86', 'macArm64', 'win-installer'])
 task current(dependsOn: [platform])
 
 task info {
@@ -325,7 +338,8 @@ task info {
         println "  current       - build for current platform ($platform)"
         println "  linux64       - builds only Linux 64-bit binary"
         println "  any           - doesn't bundle SWT, making it possible to run on ARM/Raspbian with libswt provided by OS (Experimental)"
-        println "  mac           - builds only Mac binary"
+        println "  macX86        - builds only MacX86 binary"
+        println "  macAmr64      - builds only MacArm64 binary"
         println "  win32         - builds only Windows binary"
         println "  win64         - builds only Windows 64-bit binary"
         println "  win-installer - packages a Windows installer (including both 32 and 64-bit binaries)"

--- a/build.gradle
+++ b/build.gradle
@@ -325,7 +325,9 @@ task 'win-installer'(dependsOn: ['win32', 'win64']) {
     }
 }
 
-task all(dependsOn: ['any', 'linux64', 'macX86', 'macArm64', 'win-installer'])
+task mac(dependsOn: ['macX86', 'macArm64'])
+
+task all(dependsOn: ['any', 'linux64', 'mac', 'win-installer'])
 task current(dependsOn: [platform])
 
 task info {
@@ -336,6 +338,7 @@ task info {
         println "  current       - build for current platform ($platform)"
         println "  linux64       - builds only Linux 64-bit binary"
         println "  any           - doesn't bundle SWT, making it possible to run on ARM/Raspbian with libswt provided by OS (Experimental)"
+        println "  mac           - builds only Mac binaries"
         println "  macX86        - builds only MacX86 binary"
         println "  macAmr64      - builds only MacArm64 binary"
         println "  win32         - builds only Windows binary"

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,6 @@ def platform = osName.contains("Linux") ? 'linux' + (is64 ? '64' : '32') :
                osName.contains("Windows") ? 'win' + (is64 ? '64' : '32') :
                osName.contains("OS X") ? 'mac' + (isArm ? "Arm64" : "X86") : 'unknown'
 
-println(System.getProperty("java.home"))
-
 version = gitVersion()
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     def swtVersion = '3.117.0'
     linux64 "org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:${swtVersion}"
     win64 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:${swtVersion}"
-    win32 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86:${swtVersion}"
+    win32 "org.eclipse.platform:org.eclipse.swt.win32.win32.x86:3.108.0"
     macX86 "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:${swtVersion}"
     macArm64 "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64:${swtVersion}"
     jna "net.java.dev.jna:jna:5.6.0"


### PR DESCRIPTION
This adds aarch64 support. Don't know if it is possible to bundle both arm and x86 builds like win32/64 installer.

As requested in #284 