### PR TITLE
Remember window position on screen

### DIFF
--- a/src/net/azib/ipscan/config/GUIConfig.java
+++ b/src/net/azib/ipscan/config/GUIConfig.java
@@ -26,6 +26,8 @@ public class GUIConfig {
 	public boolean askScanConfirmation;
 	
 	public int[] mainWindowSize;
+
+	public int[] mainWindowPosition;
 	public boolean isMainWindowMaximized;
 	
 	public int[] detailsWindowSize;
@@ -49,6 +51,7 @@ public class GUIConfig {
 
 		isMainWindowMaximized = preferences.getBoolean("windowMaximized", false);
 		mainWindowSize = new int[] {preferences.getInt("windowWidth", 800), preferences.getInt("windowHeight", 450)};
+		mainWindowPosition = new int[]{preferences.getInt("windowPosition-x",50), preferences.getInt("windowPosition-y",85)};
 		detailsWindowSize = new int[] {preferences.getInt("detailsWidth", 400), preferences.getInt("detailsHeight", 300)};
 	}
 
@@ -66,6 +69,9 @@ public class GUIConfig {
 		if (!isMainWindowMaximized) {
 			preferences.putInt("windowWidth", mainWindowSize[0]);
 			preferences.putInt("windowHeight", mainWindowSize[1]);
+
+			preferences.putInt("windowPosition-x",mainWindowPosition[0]);
+			preferences.putInt("windowPosition-y",mainWindowPosition[1]);
 		}
 		
 		preferences.putInt("detailsWidth", detailsWindowSize[0]);
@@ -87,6 +93,17 @@ public class GUIConfig {
 	public void setMainWindowSize(Point size, boolean isMaximized) {
 		if (!isMaximized) {
 			mainWindowSize = new int[] {size.x, size.y};
+		}
+		isMainWindowMaximized = isMaximized;
+	}
+
+	public Point getMainWindowPosition(){
+		return new Point(mainWindowPosition[0], mainWindowPosition[1]);
+	}
+
+	public void setMainWindowPosition(Point position, boolean isMaximized){
+		if (!isMaximized) {
+			mainWindowPosition = new int[] {position.x, position.y};
 		}
 		isMainWindowMaximized = isMaximized;
 	}

--- a/src/net/azib/ipscan/gui/MainWindow.java
+++ b/src/net/azib/ipscan/gui/MainWindow.java
@@ -76,6 +76,10 @@ public class MainWindow {
 
 		// after all controls are initialized, resize and open
 		shell.setSize(guiConfig.getMainWindowSize());
+
+		// remember stored position in the screen by preferences
+		shell.setLocation(guiConfig.getMainWindowPosition());
+
 		shell.open();
 		if (guiConfig.isMainWindowMaximized) {
 			shell.setMaximized(true);
@@ -99,8 +103,9 @@ public class MainWindow {
 		shell.setImage(image);
 				
 		shell.addListener(SWT.Close, event -> {
-			// save dimensions!
+			// save dimensions! and position!
 			guiConfig.setMainWindowSize(shell.getSize(), shell.getMaximized());
+			guiConfig.setMainWindowPosition(shell.getLocation(), shell.getMaximized());
 		});
 	}
 


### PR DESCRIPTION
This pull request responds to issue **[#278](https://github.com/angryip/ipscan/issues/278)**, which requested that the application remember the screen position when it restarts.

Two new attributes (`window/Position-x`, `window/position-y`) containing the X and Y coordinates of the window when closing the application have been added in the java preferences.

