### PR TITLE
feat: flatpak preparations (v2) + metadata update

### DIFF
--- a/ext/deb-bundle/usr/share/applications/ipscan.desktop
+++ b/ext/deb-bundle/usr/share/applications/ipscan.desktop
@@ -1,13 +1,13 @@
 [Desktop Entry]
-Encoding=UTF-8
+Version=1.5
+Type=Application
 Name=Angry IP Scanner
-Comment=Fast and friendly network scanner
 GenericName=Fast and friendly network scanner
+Comment=Fast and friendly network scanner
+Categories=Application;Network;Internet;Utility
 Keywords=angry;ipscan;ip;scan;scanner
 Exec=sh /usr/bin/ipscan
 Terminal=false
-Type=Application
 Icon=ipscan
-Categories=Application;Network;Internet;
-StartupWMClass=Angry IP Scanner
 StartupNotify=true
+StartupWMClass=Angry IP Scanner

--- a/ext/flatpak/ipscan
+++ b/ext/flatpak/ipscan
@@ -1,0 +1,5 @@
+#!/bin/bash
+java=$JAVA_HOME/bin/java
+[ ! -e "$java" ] && java=java
+
+"$java" --add-opens java.base/java.net=ALL-UNNAMED -jar /app/lib/ipscan/ipscan.jar "$@"

--- a/ext/flatpak/org.angryip.ipscan.metainfo.xml
+++ b/ext/flatpak/org.angryip.ipscan.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-    <id>ipscan.desktop</id>
+    <id>org.angryip.ipscan</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>GPL-2.0+</project_license>
     <name>Angry IP Scanner</name>
@@ -40,7 +40,7 @@
     <url type="vcs-browser">https://github.com/angryip/ipscan/</url>
     <url type="contribute">https://angryip.org/contribute/</url>
 
-    <launchable type="desktop-id">ipscan.desktop</launchable>
+    <launchable type="desktop-id">org.angryip.ipscan.desktop</launchable>
     <requires>
         <internet>always</internet>
     </requires>
@@ -231,4 +231,3 @@
         </release>
     </releases>
 </component>
-

--- a/ext/flatpak/org.angryip.ipscan.yaml
+++ b/ext/flatpak/org.angryip.ipscan.yaml
@@ -1,0 +1,63 @@
+app-id: org.angryip.ipscan
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk11
+command: ipscan
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --share=network
+  - --filesystem=xdg-config/gtk-3.0:ro;
+  - --persist=.swt
+  - --persist=.java
+  - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
+  - --env=JAVA_HOME=/app/jre
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk11/install.sh
+
+  - name: ipscan
+    buildsystem: simple
+    build-commands:
+      - install ipscan.jar /app/lib/ipscan/
+      - install ipscan /app/bin/
+      - desktop-file-edit --set-key=Exec --set-value=ipscan
+      - desktop-file-edit --set-key=Icon --set-value=org.angryip.ipscan
+      - install org.angryip.ipscan.desktop /app/share/applications/
+      - install org.angryip.ipscan.metainfo.xml /app/share/metainfo/
+      - install org.angryip.ipscan.svg /app/share/icons/hicolor/scalable/apps/
+
+    sources:
+      - type: file
+        url: https://github.com/angryip/ipscan/releases/download/3.9.1/ipscan-linux64-3.9.1.jar
+        sha256: b8b12628c324cddb1e1a464c1caf2597b66ce8f5f1057ffa86c1fe7b1c241b40
+        dest-filename: ipscan.jar
+        only-arches: [x86_64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/angryip/ipscan/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name=="ipscan-linux64-" + $version + ".jar") | .browser_download_url
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/deb-bundle/usr/bin/ipscan
+        sha256: 539a8fbf9e134374213385ea5478e099b026c2d573233275005c50b9046f3d9e
+        dest-filename: ipscan
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/deb-bundle/usr/share/applications/ipscan.desktop
+        sha256: 1fd9c179da838397ff582aac0e9c0eb045c2ef8228f47f6ed5a707121b50e3c0
+        dest-filename: org.angryip.ipscan.desktop
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/flatpak/org.angryip.ipscan.metainfo.xml
+        sha256: adf911dfc41ceb0b844c4d4d6c74afa1576670673cb42d3d30b8c3054cc9c15d
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon.svg
+        sha256: 1b2d31740d3d3bbd51d3d9a71d65d3859e38d10e99dd978d32fe86ed1e5d7416
+        dest-filename: org.angryip.ipscan.svg


### PR DESCRIPTION
Reference issue: #147

This PR adds the required files so flatpaks can be build under the Flathub organization infrastructure on GitHub, as well as it improves slightly the AppStream XML metadata.

Todo list moved to the reference issue

---

Changes regarding v1 PR (#416) :
- Added argument `--add-opens java.base/java.net=ALL-UNNAMED` to the bash executable
- Changed the manifest logic so it pulls files from the source repo (this one)
- Tried to use as much as possible the original metadata files

Current status:
- The entire process should be automatic and will be done (when published) by the Flathub buildbot (it updates the manifest in the Flathub repo per each new release of ipscan in this repo -> the bot checks for new releases and grabs the linux64 .jar file)
- Only per each new release a new entry should need to be added under /ext/deb-bundle/usr/share/metainfo/ipscan.appdata.xml and /ext/flatpak/org.angryip.ipscan.metainfo.xml with the release number, date, and the url to the release tag of GitHub
- Uses OpenJDK 11 Freedesktop runtime from Flathub