### PR TITLE
Modifed RangeFeederGUI, so that it removes whitespaces from IPs

### DIFF
--- a/src/net/azib/ipscan/gui/feeders/RangeFeederGUI.java
+++ b/src/net/azib/ipscan/gui/feeders/RangeFeederGUI.java
@@ -130,6 +130,11 @@ public class RangeFeederGUI extends AbstractFeederGUI {
 	}
 
 	public Feeder createFeeder() {
+
+		// Removes whitespaces from the IP and sets the IP text to the new trimmed one
+		startIPText.setText(startIPText.getText().replaceAll("\\s+",""));
+		endIPText.setText(startIPText.getText().replaceAll("\\s+",""));
+
 		return feeder = new RangeFeeder(startIPText.getText(), endIPText.getText());
 	}
 	


### PR DESCRIPTION
When I quickly wanted to test an IP range by pasting the IPs, I'd often encountered the problem that the IPs contained a whitespace character at the end, which resulted in a malformed IP.

To fix this, I modified the createFeeder function so that all whitespaces are removed before the RangerFeeder is created. Additionally, the IPs in the input fields also get updated to the trimmed IP.