### PR TITLE
feat: flatpak cleanup & support

### DIFF
--- a/ext/flatpak/ipscan
+++ b/ext/flatpak/ipscan
@@ -1,0 +1,5 @@
+#!/bin/bash
+java=$JAVA_HOME/bin/java
+[ ! -e "$java" ] && java=java
+
+"$java" --add-opens java.base/java.net=ALL-UNNAMED -jar /app/lib/ipscan/ipscan.jar "$@"

--- a/ext/flatpak/org.angryip.ipscan.desktop
+++ b/ext/flatpak/org.angryip.ipscan.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.5
+Type=Application
+Name=Angry IP Scanner
+GenericName=Fast and friendly network scanner
+Comment=Fast and friendly network scanner
+Categories=Application;Network;Internet;Utility
+Keywords=angry;ipscan;ip;scan;scanner
+Exec=sh /usr/bin/ipscan
+Terminal=false
+Icon=ipscan
+StartupNotify=true
+StartupWMClass=Angry IP Scanner

--- a/ext/flatpak/org.angryip.ipscan.metainfo.xml
+++ b/ext/flatpak/org.angryip.ipscan.metainfo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>org.angryip.ipscan</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-2.0+</project_license>
+    <name>Angry IP Scanner</name>
+    <developer_name>Anton Keks and contributors</developer_name>
+    <summary>Fast and friendly network scanner</summary>
+    <content_rating type="oars-1.0" />
+    <icon type="remote" width="128" height="128">https://angryip.org/images/icon.png</icon>
+
+    <description>
+        <p>Angry IP Scanner (or simply ipscan) is an open-source and cross-platform network scanner designed to be fast and simple to use. It scans IP addresses and ports, as well as having many other features.</p>
+        <p>It is widely used by network administrators and just curious users around the world, including large and small enterprises, banks, and government agencies.</p>
+    </description>
+
+    <screenshots>
+        <screenshot type="default">
+            <caption>A scan was performed</caption>
+            <image type="source">https://angryip.org/screenshots/ipscan-ubuntu.png</image>
+        </screenshot>
+    </screenshots>
+
+    <categories>
+        <category>Network</category>
+        <category>Utility</category>
+    </categories>
+
+    <keywords>
+      <keyword>angry</keyword>
+      <keyword>ipscan</keyword>
+      <keyword>ip</keyword>
+      <keyword>scan</keyword>
+      <keyword>scanner</keyword>
+    </keywords>
+
+    <url type="homepage">https://angryip.org/</url>
+    <url type="bugtracker">https://github.com/angryip/ipscan/issues/</url>
+    <url type="faq">https://angryip.org/faq/</url>
+    <url type="help">https://angryip.org/documentation/</url>
+    <url type="vcs-browser">https://github.com/angryip/ipscan/</url>
+    <url type="contribute">https://angryip.org/contribute/</url>
+
+    <launchable type="desktop-id">org.angryip.ipscan.desktop</launchable>
+    <requires>
+        <internet>always</internet>
+    </requires>
+
+    <releases>
+        <release version="3.9.1" date="2023-02-11">
+            <url>https://github.com/angryip/ipscan/releases/tag/3.9.1</url>
+        </release>
+    </releases>
+</component>

--- a/ext/flatpak/org.angryip.ipscan.yaml
+++ b/ext/flatpak/org.angryip.ipscan.yaml
@@ -1,0 +1,80 @@
+app-id: org.angryip.ipscan
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk11
+command: ipscan
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --share=network
+  - --filesystem=xdg-config/gtk-3.0:ro;
+  - --persist=.swt
+  - --persist=.java
+  - --env=PATH=/usr/bin:/app/bin:/app/jre/bin
+  - --env=JAVA_HOME=/app/jre
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk11/install.sh
+
+  - name: ipscan
+    buildsystem: simple
+    build-commands:
+      - install ipscan.jar /app/lib/ipscan/
+      - install ipscan /app/bin/
+      - desktop-file-edit --set-key=Exec --set-value=ipscan
+      - desktop-file-edit --set-key=Icon --set-value=org.angryip.ipscan
+      - install org.angryip.ipscan.desktop /app/share/applications/
+      - install org.angryip.ipscan.metainfo.xml /app/share/metainfo/
+      - install org.angryip.ipscan.svg /app/share/icons/hicolor/scalable/apps/
+      - install org.angryip.ipscan32.png /app/share/icons/hicolor/32x32/apps/org.angryip.ipscan.png/
+      - install org.angryip.ipscan48.png /app/share/icons/hicolor/48x48/apps/org.angryip.ipscan.png/
+      - install org.angryip.ipscan128.png /app/share/icons/hicolor/128x128/apps/org.angryip.ipscan.png/
+      - install org.angryip.ipscan256.png /app/share/icons/hicolor/256x256/apps/org.angryip.ipscan.png/
+
+    sources:
+      - type: file
+        url: https://github.com/angryip/ipscan/releases/download/3.9.1/ipscan-linux64-3.9.1.jar
+        dest-filename: ipscan.jar
+        only-arches: [x86_64]
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/angryip/ipscan/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name=="ipscan-linux64-" + $version + ".jar") | .browser_download_url
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/flatpak/ipscan
+        dest-filename: ipscan
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/deb-bundle/usr/share/applications/ipscan.desktop
+        dest-filename: org.angryip.ipscan.desktop
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/ext/flatpak/org.angryip.ipscan.metainfo.xml
+        # sha256: adf911dfc41ceb0b844c4d4d6c74afa1576670673cb42d3d30b8c3054cc9c15d
+        dest-filename: org.angryip.ipscan.metainfo.xml
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon.svg
+        dest-filename: org.angryip.ipscan.svg
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon32.png
+        dest-filename: org.angryip.ipscan32.png
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon48.png
+        dest-filename: org.angryip.ipscan48.png
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon128.png
+        dest-filename: org.angryip.ipscan128.png
+
+      - type: file
+        url: https://raw.githubusercontent.com/angryip/ipscan/master/resources/images/icon256.png
+        dest-filename: org.angryip.ipscan256.png


### PR DESCRIPTION
Reference issue, which seems to have been deleted: https://github.com/angryip/ipscan/issues/147

v2 PR: https://github.com/angryip/ipscan/pull/424

Pending things:
- Publish on Flathub.
- Package verification (optional).
- Add flathub.json file to specify that only x86_64 arch is supported.

Let's see how this goes.