### PR TITLE
Added Irish translation

### DIFF
--- a/resources/messages_ga_IE.properties
+++ b/resources/messages_ga_IE.properties
@@ -1,0 +1,364 @@
+# Messages in properties format
+# To translate, copy this file to e.g. messages_fr.txt, where "fr" is the language code
+# Country-specific language variants are also supported, e.g. messages_fr_CA.txt
+# Please delete untranslated lines, include only those which are translated
+# Note: all messages files should be in UTF-8 encoding
+
+preferences.language=Teanga
+preferences.language.needsRestart=Ní mór duit an aip a atosú le go dtiocfaidh an t-athrú teanga i bhfeidhm
+preferences.language.someIncomplete=Tá roinnt aistriúcháin neamhiomlán
+
+language.system=Réamhshocrú córais
+language.en=English
+language.ru=Русский
+language.de=Deutsch
+language.es=Español
+language.fi=Suomi
+language.ga=Gaeilge
+language.gr=Ελληνικά
+language.fr=Français
+language.hu=Magyar
+language.it=Italiano
+language.ku=کوردی
+language.lt=Lietuvių
+language.tr=Türkçe
+language.pt_BR=Português (BR)
+language.zh_TW=正體中文
+language.zh_CN=简体中文
+
+preferences.csv=CSV
+preferences.csv.separator=Deighilteoir CSV
+text.progress.ipProgressBar=Stádas IP:
+text.progress.portProgressBar=Stádas poirt:
+menu.scan=&Scanadh
+menu.scan.newWindow=&Fuinneog nua
+menu.scan.exportAll=&Easpórtáil go léir...
+menu.scan.exportSelection=Easpórtáil an&roghnaithe...
+menu.scan.exportPreferences=Easpórtáil &roghanna...
+menu.scan.importPreferences=&Iompórtáil sainroghanna...
+menu.scan.quit=&Scoir
+menu.scan.load=&Lódáil torthaí...
+menu.goto=&Téigh go
+menu.goto.next.aliveHost=&An chéad óstach beo eile
+menu.goto.next.deadHost=An chéad óstach eile &marbh
+menu.goto.next.openPort=An chéad oscailt eile &port
+menu.goto.prev.aliveHost=&Óstach beo roimhe seo
+menu.goto.prev.deadHost=Óstach marbh roimhe s&eo
+menu.goto.prev.openPort=Por&t oscailte roimhe seo
+menu.goto.find=&Faigh...
+menu.commands=&Orduithe
+menu.commands.details=&Taispeáin sonraí
+menu.commands.rescan=&Athscanadh IP(anna)
+menu.commands.delete=&Scrios IP(anna)
+menu.commands.copy=&Cóipeáil IP
+menu.commands.copyDetails=Cói&peáil sonraí
+menu.commands.show=Taispeáin
+menu.commands.open=Oscail
+menu.commands.open.edit=Cuir oscailteoirí in eagar...
+menu.favorites=Ceanáin
+menu.favorites.add=Cuir reatha leis...
+menu.favorites.edit=&Bainistigh ceanáin...
+menu.tools=&Uirlisí
+menu.tools.preferences=&Sainroghanna...
+menu.tools.fetchers=&Faighteoirí...
+menu.tools.select=Toghchán
+menu.tools.select.alive=Óstáin &Beo
+menu.tools.select.dead=&Óstaigh marbh
+menu.tools.select.withPorts=Le &poirt oscailte
+menu.tools.select.withoutPorts=Gan o&poirt oscailte
+menu.tools.select.invert=Roghnú inbhéartaithe
+menu.tools.scanStatistics=Scanadh s&taitistic
+menu.help=&Cabhair
+menu.help.gettingStarted=Ag &Tosú
+menu.help.website=Láithreán gréasáin oifigiúil
+menu.help.faq=CCanna
+menu.help.issues=Tuairiscigh saincheist
+menu.help.plugins=Breiseáin
+menu.help.cmdLine=Úsáid líne ordaithe
+menu.help.checkVersion=Seiceáil do leagan níos nuaí...
+menu.help.about=&Maidir
+menu.columns.sortBy=Sórtáil de réir
+menu.columns.sortDirection=Athraigh treo sórtála
+menu.columns.about=Maidir
+menu.columns.preferences=roghanna...
+state.ready=Réidh
+state.scanning=Thosaigh\u0020
+state.waitForThreads=Fan go gcríochnóidh na snáitheanna go léir...
+state.killingThreads=Gach snáithe a mharú...
+state.exporting=Torthaí á n-easpórtáil...
+state.searching=Ag cuardach...
+state.opening=Ag oscailt
+state.retrievingVersion=An leagan is déanaí á fháil ar ais ...
+title.about=Maidir
+title.configDetect=Brath Cumraíochta
+title.statistics=Staitisticí Scanadh
+title.preferences=Roghanna
+title.preferences.scanning=&Ag scanadh
+title.preferences.display=&Taispeáin
+title.preferences.fetchers=&Faighteoirí
+title.preferences.ports=&Poirt
+title.details=Sonraí seoladh IP
+title.exportAll=Easpórtáil Gach Torthaí
+title.exportSelection=Easpórtáil Torthaí Roghnaithe
+title.gettingStarted=Tús a chur leis
+title.favorite.add=Cuir is fearr leat
+title.favorite.edit=Cuir ceanáin in eagar
+title.openers.edit=Cuir Oscailteoirí in Eagar
+title.fetchers=Faighteoirí
+title.fetchers.select=Roghnaigh Faighteoirí...
+title.rename=Athainmnigh
+title.load=Lódáil
+title.find=Faigh
+title.commandline=Úsáid Líne Ordú
+text.error=Earráid
+text.userError=Fadhb
+text.ip=IP
+text.threads=Snáitheanna:\u0020
+text.threads.max=\u0020(uas)
+text.display.ALL=Taispeáin: Gach
+text.display.ALIVE=Taispeáint: Beo amháin
+text.display.PORTS=Taispeáin: Poirt oscailte
+text.hostsSelected=\u00A0óstach roghnaithe
+text.favorite.add=Cuir isteach ainm an rogha nua
+text.favorite.edit=Anseo thíos is féidir leat ceanáin a athshocrú nó a scriosadh
+text.find=Cuir isteach an téacs chun cuardach a dhéanamh air
+text.find.notFound=Baineadh deireadh leis an liosta gan aon mheaitseáil.
+text.find.restart=Atosaigh ón tús?
+text.comment.edit=Trácht
+text.configDetect=Déanfaimid iarracht líon na snáitheanna a oibríonn go hiontaofa ar an meaisín seo a bhrath trí nascadh le hóstach aitheanta go minic agus úsáid á baint as an teorainn ama cumraithe don phoirt.\n\nSoláthair óstach agus port atá 100% oscailte agus a oibríonn, m.sh. seachfhreastalaí nó freastalaí gréasáin ar do líonra.
+text.configDetect.host=Óstach:
+text.configDetect.port=Port:
+text.configDetect.tries=Naisc tionscanta:
+text.configDetect.successes=Naisc rathúla:
+text.configDetect.failed=Rinneadh %d iarracht ceangail san iomlán. Bhíothas ag súil go n-éireodh le %d díobh, ach níor oibrigh ach %d i ndáiríre. Dealraíonn sé gur dócha go gcaithfidh tú an t-uaslíon snáitheanna a shocrú ar luach níos ísle nó an teorainn ama ceangail a mhéadú.
+text.configDetect.success=Oibríonn an líon snáitheanna roghnaithe de %d go foirfe ar do ríomhaire.
+text.scan.new=Scanadh nua
+text.scan.confirmation=An bhfuil fonn ort na torthaí scanadh roimhe seo a scriosadh?
+text.scan.resume=Is é %LASTIP an seoladh IP deiridh.\nAn scanadh luchtaithe arís go dtí %ENDIP?
+text.scan.completed=Scanadh críochnaithe
+text.scan.incomplete=Scanadh neamhiomlán
+text.scan.aborted=Cuireadh deireadh leis an scanadh
+text.scan.time.total=Am iomlán:
+text.scan.time.average=Meán-am in aghaidh an óstaigh:
+text.scan.hosts.total=Scanadh na hóstach:
+text.scan.hosts.alive=Óstach beo:
+text.scan.hosts.ports=Le poirt oscailte:
+text.version.latest=Tá an leagan is déanaí á rith agat
+text.version.old=Is é %LATEST an leagan cobhsaí is déanaí, ach tá %VERSION á rith agat.\n\nAr mhaith leat an leathanach íoslódála a oscailt anois?
+text.openers.edit=Anseo thíos is féidir leat oscailteoirí nua a chur in eagar nó a chur leis
+text.openers.name=Ainm an oscailteora (mír roghchláir):
+text.openers.string=Teaghrán feidhmithe:
+text.openers.directory=Eolaire oibre:
+text.openers.inTerminal=Rith i teirminéal
+text.openers.new=Oscailteoir nua
+text.openers.hint=&Ionadaithe...
+text.openers.hintText=Is féidir leat aon luachanna scanta a sheol na hiontairí sa teaghrán feidhmithe a úsáid.\n\nTá na hiontairí seo a leanas ar fáil le hionadú faoi láthair:\n\n
+text.fetchers.select=Anseo is féidir leat faighteoirí a roghnú le scanadh. Léirítear Faighteoirí ag colúin.
+text.fetchers.selectedList=Seoltóirí roghnaithe
+text.fetchers.availableList=Gabhair ar fáil
+text.fetchers.info=Faigh eolas:
+text.fetchers.info.notAvailable=Ar an drochuair, níl aon fhaisnéis bhreise faoin ngabhálaí seo ar fáil.
+text.fetchers.preferences=Sainroghanna an ghabhálas roghnaithe
+text.fetcher.portText.send=Tá téacs le seoladh (\\ n, \\r, \\t agus \\xXX ceadaithe)
+text.fetcher.portText.match=Regexp le meaitseáil sa fhreagra, líne ar líne
+text.fetcher.portText.replace=Teaghrán athsholáthair Regexp ($0 .. $9 in ionad grúpaí comhoiriúnaithe)
+text.about=%NAME\n\nLeagan: %VERSION\nDáta tóg: %DATE\n\n%COPYLEFT
+text.about.system=Java: % Java\nOS: % OS\nSWT: % SWT
+button.OK=&Ceart go leor
+button.cancel=&Cealaigh
+button.find.next=Aimsigh &Ar Aghaidh
+button.close=&Dún
+button.next=&Ar Aghaidh
+button.start=Tosaigh
+button.stop=Stad
+button.kill=Stad!
+button.ipUp=IP↑
+button.up=\u00A0↑\u00A0
+button.up.hint=Bog suas
+button.down=\u00A0↓\u00A0
+button.down.hint=Bog síos
+button.left=\u00A0←\u00A0
+button.left.hint=Cuir
+button.right=\u00A0 →\u00A0
+button.right.hint=Bain
+button.delete=Dí&le
+button.rename=&Athainmnigh
+button.save=&Sábháil
+button.insert=&Cuir isteach
+button.add=&Cuir leis
+button.check=Seiceáil&k...
+combobox.feeder.tooltip=Roghnú Fothaire IP. Athraigh é seo má tá foinse eile uait chun seoltaí IP a scanadh
+pinger.windows=Windows ICMP
+pinger.udp=Pacáiste UDP
+pinger.tcp=Insamhlóir TCP port
+pinger.combined=Comhcheangailte UDP+TCP
+pinger.java=Java Insuite
+pinger.arp=ARP (LAN amháin)
+opener.web=Brabhsálaí Gréasáin
+opener.ftp=FTP
+opener.telnet=Telnet
+opener.ssh=SSH
+opener.ping=Ping
+opener.traceroute=Rian bealach
+opener.whois=Whois
+opener.geolocate=Geo lonnú
+opener.netbios=Scaireanna Windows
+opener.email=Sampla r-phoist
+feeder.range=Raon IP
+feeder.range.to=chuig
+feeder.range.startIP=Tosaigh IP
+feeder.range.endIP=Críochnaigh IP
+feeder.range.netmask=Masc glan
+feeder.range.netmask.tooltip=Netmask den raon IP. Úsáid líon na ngiotán (m.sh. /24) nó an nodaireacht poncaithe (.255. = ..)
+feeder.range.hostname=Óstainm
+feeder.range.hostname.tooltip=Úsáid an réimse seo chun óstainmneacha chuig seoltaí IP a réiteach
+feeder.file=Comhad Téacs
+feeder.file.name=Comhad
+feeder.file.browse=Brabhsáil...
+feeder.random=Randamach
+feeder.random.prototype=Bonn IP
+feeder.random.mask=Masc IP
+feeder.random.hostname=Óstainm
+feeder.random.count=Áireamh
+feeder.rescan.of=Athscanadh\u0020
+fetcher.ip=IP
+fetcher.ip.info=Taispeánann sé an seoladh IP scanta.\nTá an t-aimsitheoir seo éigeantach agus ní féidir é a bhaint den liosta.
+fetcher.ping=Ping
+fetcher.ping.info=Taispeánann sé cibé an bhfreagraíonn an t-óstach ar iarratais ping agus taispeánann sé am meánturas paicéad chuig an ósta agus ar ais má aimsíodh é (ag brath ar an modh pinging a roghnaíodh sa dialóg Roghanna).
+fetcher.ping.ttl=TTL
+fetcher.ping.ttl.info=Taispeánann sé an luach TTL (Time To Live) i bpacáistí freagartha ping (ní oibríonn sé ach le pinging ICMP).\n\nDéantar an luach seo a laghdú de ghnáth ag gach nód sa líonra a chuireann an paicéad ar aghaidh, mar sin más féidir an luach tosaigh a thomhas (64, de ghnáth, 128, nó 255), ansin léiríonn an difríocht an t-achar go dtí an ósta (i líon na nóid).
+fetcher.packetloss=Caillteanas Paicéad
+fetcher.packetloss.info=Taispeánann sé líon na bpacáistí a cailleadh as iomlán na bpaicéad ping a seoladh.
+fetcher.hostname=Ainm óstach
+fetcher.hostname.info=Taispeánann sé ainm an óstaigh a fuair an cuardach DNS droim ar ais.\n\nSeo é ainm an óstaigh cláraithe ar an DNS
+fetcher.ports=Poirt
+fetcher.ports.info=Taispeánann sé liosta na bport oscailte ó na cinn a scanadh.\n\nTá port oscailte nuair is féidir croitheadh ​​láimhe TCP a chríochnú agus nasc a bhunú.\nIs féidir leat poirt scanta a roghnú sa dialóg Roghanna.\n\nAn léiríonn an uimhir sa cheannteideal colún líon reatha na gcalafort roghnaithe le scanadh; Taispeántar '+' má scanadh poirt iarrtha do gach óstaigh freisin.
+fetcher.ports.filtered=Poirt Scagtha
+fetcher.ports.filtered.info=Taispeánann sé liosta na bport scagtha ó na cinn a scanadh.\n\nDéantar port a scagadh nuair nach bhfaightear freagra ar an iarracht ceangail laistigh den tréimhse ama sonraithe. Má tá calafort scagtha, ansin is dócha go bhfuil sé bactha ag balla dóiteáin.
+fetcher.comment=Tuairimí
+fetcher.comment.info=Taispeánann sé na nótaí tráchta a iontráladh don seoladh ag baint úsáide as an bhfuinneog Sonraí IP.\nTá na nótaí tráchta fós ann agus taispeántar iad nuair a scanadh an t-óstach seo arís.
+fetcher.webDetect=Brath gréasáin
+fetcher.webDetect.info=Aimsítear ainm agus leagan bogearraí an fhreastalaí gréasáin, más féidir.\n\nOibrítear leis seo trí iarratas HEAD a sheoladh agus ceanntásc an fhreastalaí HTTP a léamh ón bhfreagra.
+fetcher.httpSender=Seoltóir HTTP
+fetcher.httpSender.info=Seoltar na hiarratais téacs sonraithe chuig an gcalafort TCP sonraithe (m.sh. 80), aisghabhann sé an freagra agus úsáideann an slonn sonraithe rialta chun an fhaisnéis atá ag teastáil a bhaint amach.\n\nAn-inoiriúnaithe, is féidir é a úsáid le haghaidh aon phrótacail téacs, mar HTTP, SMTP, POP3, IMAP, etc. D'úsáideoirí chun cinn.
+fetcher.httpProxy=Seachfhreastalaí HTTP
+fetcher.httpProxy.info=Aimsíonn sé cibé an bhfuil seachfhreastalaí HTTP oibre ag rith ar an ósta ar cheachtar calafort 3128, aon chalafoirt oscailte scanta, nó an calafort iarrtha lódáilte ag baint úsáide as File Feeder i bhformáid óstach:port.
+fetcher.portText.custom=Saincheaptha
+fetcher.netbios=Eolas NetBIOS
+fetcher.netbios.info=Aisghabhann sé an fhaisnéis NetBIOS faoi mheaisíní Windows.\n\nTá an fhormáid seo a leanas ag an bhfreagra:\nDOMAIN\USER@COMPUTER [MAC]\n\nCá:\nDOMAIN - fearann ​​nó grúpa oibre Windows\nUSER - úsáideoir logáilte isteach faoi láthair\nCOMPUTER - Ainm ríomhaire Windows (seans go bhfuil sé difriúil ón ainm DNS)\nSeans go mbeidh roinnt codanna as láthair, ag brath ar an bhfreagra.\n\nTabhair faoi deara nach n-oibreoidh sé seo le meaisíní a bhfuil balla dóiteáin cumasaithe (is iad na suiteálacha is nua-aimseartha).\nCuirtear an t-aimseoir seo ar fáil go príomha le haghaidh comhoiriúnachta gné le leagan 2.x.
+fetcher.mac=Seoladh MAC
+fetcher.mac.info=Réitíonn sé seoladh MAC an óstaigh ar an líonra áitiúil trí úsáid a bhaint as an bprótacal ARP.\nNí oibreoidh sé d'óstach líonra neamh-áitiúil.
+fetcher.mac.vendor=Díoltóir MAC
+fetcher.mac.vendor.info=Taispeánann sé ainm an díoltóra a d'fhéadfadh an cárta líonra a tháirgeadh leis an seoladh MAC réitithe.
+fetcher.mac.separator=Deighilteoir seoltaí MAC
+fetcher.value.notAvailable=[n/a]
+fetcher.value.notScanned=[n/s]
+unit.ms=\u00A0ms
+unit.second=\u00A0soic
+unit.minute=\u00A0noim
+unit.hour=\u00A0uair
+preferences.threads=Snáitheanna
+preferences.threads.delay=Moill idir snáitheanna tosaigh (in ms):
+preferences.threads.maxThreads=Uasmhéid snáitheanna:
+preferences.pinging.deadHosts=Scanadh óstaigh marbh, nach bhfreagraíonn pings
+preferences.pinging=Pinging
+preferences.pinging.type=Modh pingin:
+preferences.pinging.count=Líon na tóireadóirí ping (paicéid le seoladh):
+preferences.pinging.timeout=Am istigh ping (in ms):
+preferences.skipping=Scipeáil
+preferences.skipping.broadcast=Scipeáil ar sheoltaí IP neamhshannta *.0 agus *.255 is dócha
+preferences.fetchers.info=Anseo is féidir leat sainroghanna a athrú go sonrach do na hiontairí
+preferences.ports.timing=Am
+preferences.ports.timing.timeout=Am istigh ceangail an port réamhshocraithe (in ms):
+preferences.ports.timing.adaptTimeout=Cuir an t-am istigh in oiriúint don am turais bhabhta ping (má tá sé ar fáil)
+preferences.ports.timing.minTimeout=Am istigh íosta ceangail oiriúnaithe (in ms):
+preferences.ports.ports=Roghnú poirt
+preferences.ports.portsDescription=Sonraigh poirt le scanadh anseo. Tacaítear le raonta.\nSampla: 1-3,5,7,10-15,6000-6100\nMá shonraítear go leor port, féadfaidh an scanadh go leor ama a ghlacadh.
+preferences.ports.addRequested=I gcás gach óstaigh, cuir poirt iarrtha ó fhriothálaí comhaid leis
+preferences.ports.addRequested.info=Seans go dtacóidh Fothairí le poirt iarrtha a shonrú chomh maith le seoltaí (m.sh. Fothaire Comhad, i bhfoirm seoladh:port)\nCeadaíonn sé seo do chomhaid liosta IP:Poirt easpórtáilte a athscanáil. D'fhéadfadh sé a bheith úsáideach le haghaidh liostaí seachfhreastalaí HTTP agus a leithéid.\nMá sheiceáiltear é seo, déanfar poirt iarrtha gach óstaigh a scanadh i gcónaí chomh maith leis na poirt choitianta atá sonraithe thuas.
+preferences.display.list=Taispeáin i liosta na dtorthaí
+preferences.display.list.ALL=Gach óstaigh scanta
+preferences.display.list.ALIVE=Óstaighéirí beo (ag freagairt do pings) amháin
+preferences.display.list.PORTS=Óstríomhairí le poirt oscailte amháin
+preferences.display.labels=Óstaigh le poirt oscailte amháin
+preferences.display.labels.notAvailable=Lipéid ar taispeáint i liosta na dtorthaí
+preferences.display.labels.notScanned=Níl an luach ar fáil (gan torthaí):
+preferences.display.confirmation=Deimhniú
+preferences.display.confirmation.newScan=Iarr dearbhú sula dtosaíonn tú ar scanadh nua
+preferences.display.confirmation.showInfo=Taispeáin dialóg faisnéise tar éis gach scanadh
+preferences.allowReports=Seol tuairiscí earráide gan ainm
+preferences.versionCheck=Seiceáil le haghaidh leaganacha nua
+exporter.txt=Comhad téacs (txt)
+exporter.txt.genered=Ginte ag
+exporter.txt.scanned=Scanadh
+exporter.csv=Comhad camógdheighilte (csv)
+exporter.xml=Comhad XML (xml)
+exporter.ipList=IP:Liosta poirt (lst)
+exporter.sql=Comhad SQL (sql)
+exception.FeederException.invalidNetmask=Masc glan neamhbhailí sonraithe. Caithfidh sé a bheith san fhormáid ABCD nó /bits
+exception.FeederException.invalidHostname=Sonraíodh óstainm neamhbhailí nó nach bhfuil ann
+exception.FeederException.malformedIP=Seoladh IP míchumtha sonraithe, ba cheart go mbeadh cuma A.B.C.D air
+exception.FeederException.differentProtocols=Caithfidh an dá IP a bheith ina IPv4 nó IPv6
+exception.FeederException.random.invalidCount=Ní mór comhaireamh seolta randamach a bheith níos mó ná 0
+exception.FeederException.file.notExists=Níl an comhad sonraithe ann nó níl cead agat é a léamh
+exception.FeederException.file.errorWhileReading=Earráid agus an comhad á léamh
+exception.FeederException.file.nothingFound=Níor aimsíodh aon seoladh IP sa chomhad
+exception.FetcherException.preferences.notAvailable=Níl aon sainroghanna ag an ngabhálaí seo.
+exception.FetcherException.unparseablePortString=Tá teaghrán an phoirt neamhbhailí nó neamhiomlán.\nCinntigh go bhfuil sé san fhormáid cheart agus go bhfuil uimhreacha poirt sa raon ceart (1-65535)
+exception.FetcherException.unsupportedPinger=Ní thacaítear leis an bpinger roghnaithe sa timpeallacht reatha.\n\nIs féidir é seo a dhéanamh le pingers ICMP, a dteastaíonn tacaíocht RawSocket ón gcóras oibriúcháin agus pribhléidí fréimhe uathu
+exception.FetcherException.pingerCreateFailure=Ní féidir an pinger iarrtha a thúsú.\nIs féidir leat triail a bhaint as pinger eile a roghnú sa dialóg Roghanna.
+exception.ExporterException.failed=Theip ar easpórtáil
+exception.ExporterException.exporter.unknown=Cineál comhaid anaithnid, sonraigh an iarmhír cheart in ainm an chomhaid.
+exception.ExporterException.xml.noAppend=Ní thacaítear le cur le comhaid XML.
+exception.ExporterException.fetcher.notFound=Níl go leor sonraí sna torthaí scanadh chun easpórtáil go dtí an cineál comhaid seo.
+exception.ExporterException.scanningInProgress=Níl an scanadh críochnaithe fós. Ar mhaith leat torthaí neamhiomlána a easpórtáil anois?
+exception.UserErrorException.openURL.failed=Ní féidir do bhrabhsálaí réamhshocraithe a sheoladh, tá brón orainn.\nURL:
+exception.UserErrorException.openTerminal.failed=Níorbh fhéidir an teirminéal a sheoladh, tá brón orm\n
+exception.UserErrorException.opener.failed=Ní féidir próiseas seachtrach a sheoladh, tá brón orainn.\nCommand-line:
+exception.UserErrorException.opener.unknownFetcher=Ní féidir an t-aimsitheoir tagartha a réiteach sa toradh scanadh reatha. Ní féidir an t-oscailteoir a rith le paraiméadar:
+exception.UserErrorException.opener.nullFetcherValue=Tá luach athsholáthair an ghlacadóra folamh sna torthaí scanta. Ní féidir an t-oscailteoir a rith le paraiméadar:
+exception.UserErrorException.opener.edit.noSelection=Roghnaigh an t-ionad inar mian leat d'oscailteoir a shábháil agus nó an cnaipe Ionsáigh chun ceann nua a chur leis.
+exception.UserErrorException.commands.noSelection=Níor roghnaíodh seoladh IP
+exception.UserErrorException.commands.noResults=Níl aon torthaí scanta ar fáil, déan scanadh ar dtús
+exception.UserErrorException.favorite.alreadyExists=Tá an ceann is fearr leat leis an ainm céanna ann cheana, bain triail as ceann eile
+exception.UserErrorException.version.latestFailed=Theip ar an leagan is déanaí a fháil. Tabhair cuairt ar an suíomh Gréasáin de láimh.
+exception.UserErrorException.fileLoad.failed=Níorbh fhéidir torthaí a luchtú ón gcomhad. Déan cinnte gur onnmhairíodh Angry IP Scanner an comhad roimhe seo.
+exception.OutOfMemoryError=As Cuimhne. Sáraíodh an méid atá ar fáil do chuimhne carn an chláir.\nMéadaigh uasmhéid an charn don ríomhchlár seo, le do thoil.
+
+text.gettingStarted=Caochadán
+
+text.gettingStarted1=Is uirlis scanóir seoltaí IP é an Scanóir IP Angry.\n\n\
+Úsáidtear é chun seoltaí IP a scanadh agus é mar aidhm óstach beo a aimsiú agus faisnéis spéisiúil a bhailiú faoi gach ceann acu.\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n>
+Is féidir leat tosú trí na seoltaí IP atá le scanadh a shonrú (cuirtear do IP áitiúil isteach de réir réamhshocraithe) agus cliceáil ar an gcnaipe Tosaigh.
+
+text.gettingStarted2=Príomh téarmaíocht:\n\n\
+Fothaire - gineadóir seoltaí IP le scanadh. Soláthraíonn Scanóir IP Angry cineálacha éagsúla friothálacha: Raon IP, Randamach, agus Comhad Liosta IP. Is féidir leat friothálacha a roghnú ag baint úsáide as an mbosca teaglama in aice leis an gcnaipe Tosaigh.\n\n\
+Fetcher - bailíonn sé faisnéis shonrach faoi óstach, e.g. am ping, óstainm, calafoirt oscailte. Is gnách go seasann faighteoirí  do cholúin i liosta na dtorthaí scanadh. Is féidir leat faighteoirí  breise a roghnú trí "Tools-> Roghnaigh fetchers" a roghnú ón roghchlár.
+
+text.gettingStarted3=Príomhthéarmaíocht:\n\n\
+Óstach beo - Is é an ósta, ag freagairt do pinging. Tá siad seo gorm i liosta na dtorthaí.\n\n\
+Óstach marbh - nach bhfuil an ósta, freagra a thabhairt ar pinging (dearg ar an liosta). Mar sin féin, d'fhéadfadh sé a bheith fós calafoirt oscailte (má pings bloic balla dóiteáin). Chun na hóstach seo a scanadh go hiomlán, seiceáil "scan hosts dead" sa dialóg Tools->Preferences.\n\n\
+Port oscailte - Port TCP, ag freagairt iarrachtaí nasc. Tá glas ar na hóstach le poirt oscailte i liosta na dtorthaí.\n\n\
+Port scagtha - Port TCP, gan freagairt go bhfuil sé dúnta (gan paicéad RST). Is gnách go gcuirtear bac ar na calafoirt seo go sonrach le ballaí dóiteáin ar chúis éigin.
+
+text.gettingStarted4=Pinging (seiceáil an bhfuil óstaigh beo):\n\n\
+Is féidir le Scanóir IP Angry modhanna éagsúla a úsáid le haghaidh óstaigh pinging. Is féidir leat rogha a dhéanamh eatarthu sa dialóg Roghanna.\n\n\
+Macalla ICMP - is é an modh caighdeánach a úsáideann an clár 'ping'. Éilíonn an ceann seo pribhléidí riarthóra nó fréimhe ar fhormhór na n-ardán. Tabhair faoi deara go ndéanann roinnt bogearraí balla dóiteáin seoladh paicéid freagartha macalla ICMP a dhíchumasú, rud a fhágann go bhfuil cuma marbh ar óstaigh bheo.\n\n\
+UDP - seolann paicéid UDP (datagrams) chuig ceann de chalafoirt an óstaigh agus féach an bhfuil aon fhreagra (dearfach nó diúltach). Tá sé seo neamhchaighdeánach, ach oibríonn sé gan pribhléidí speisialta.\n\n\n
+TCP - déanann sé iarracht ceangal a dhéanamh le port 80 (http) ar an ósta. Seans go n-oibreoidh sé seo níos fearr ná an UDP do líonraí áirithe, ach de ghnáth bíonn sé níos measa.\n\n\
+Is minic nach n-aimsíonn pinginí UDP agus TCP ródairí nó trealamh líonra eile i gceart.\n\n\
+TTL (am le maireachtáil) - ní oibríonn an fetcher seo ach le modh pinging ICMP. Is é 64 nó 128 a luach tosaigh de ghnáth, agus is ionann an difríocht agus an fad go dtí an t-óstach i líon na nóid a thaistil sé.
+
+text.gettingStarted5=Taispeánann liosta na dtorthaí na torthaí scanadh, líne amháin in aghaidh gach seoladh scanta.\n\n\
+Ag baint úsáide as an dialóg Roghanna, is féidir leat a chumrú chun taispeáint:\n\
+- gach óstaigh scanta\n\
+- ina hóstach beo amháin\n\
+- ina hóstach amháin a bhfuil aon phoirt ar oscailt\n\n\
+Luachanna speisialta (inchumraithe freisin):\n\
+[n/s] - luach gan scanadh nár scanadh ar chor ar bith (m.sh. má tá an t-óstach marbh)\n\
+[n/a] - níl an luach ar fáil, ach scanadh é
+
+text.crippledWindowsInfo=Go raibh maith agat as Angry IP Scanner a thriail!\n\n\
+Coinnigh i gcuimhne, áfach, go bhfuil cumas teoranta ag leaganacha tomhaltóra de Windows (m.sh. Windows XP SP2 / Vista / 7) a bheith ina n-óstach le haghaidh scanadh, mar gheall ar thacaíocht RawSocket bainte agus teorannú ráta ceangail TCP.\n\n\
+Mar gheall air sin, athraíodh roinnt sainroghanna duit, rud a d'fhág go raibh an scanadh níos moille ná mar a bhí ar chórais oibriúcháin eile.\n\n\
+Féach ar an leathanach Ceisteanna Coitianta ar an suíomh Gréasáin (úsáid an roghchlár Cabhrach) chun tuilleadh eolais a fháil.


### PR DESCRIPTION
Added Irish language translation.  Some details of the language:-

- **Language Code**: `ga`  
- **Official Name**: Irish  
- **Native Name**: Gaeilge  
- **ISO Code**: 639-1  
- **Region**: Ireland, European Union  

This commit adds support for the Irish language (Gaeilge) in Angry IP Scanner, making the tool more accessible to Irish speakers. Thank you!