### PR TITLE
Fix UnsupportedOperationException in FeederActions

### DIFF
--- a/src/net/azib/ipscan/gui/actions/FeederActions.java
+++ b/src/net/azib/ipscan/gui/actions/FeederActions.java
@@ -82,7 +82,7 @@ public class FeederActions {
 				};
 
 				for (var networkInterface : getNetworkInterfaces()) {
-					var addresses = networkInterface.getInterfaceAddresses();
+					var addresses = new java.util.ArrayList<>(networkInterface.getInterfaceAddresses());
 					addresses.sort(comparing(i -> i.getAddress().getAddress().length));
 					for (var ifaddr : addresses) {
 						if (ifaddr == null) continue;


### PR DESCRIPTION
When selecting a local IP address from the UI, an `UnsupportedOperationException` is thrown on modern Java versions because `networkInterface.getInterfaceAddresses()` returns an unmodifiable list. This PR wraps the list in an `ArrayList` before sorting to fix the issue.