### PR TITLE
Add SECURITY.md to enable private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+
+  # Security Policy
+
+  ## Supported Versions
+
+  Only the latest release of Angry IP Scanner receives security fixes.
+
+  | Version        | Supported |
+  |----------------|-----------|
+  | 3.9.3 (latest) | Yes       |
+  | < 3.9.3        | No        |
+
+ 
+  ## Reporting a Vulnerability
+
+  Please **do not** open a public GitHub issue for security vulnerabilities.
+
+  **Preferred channel — GitHub Private Advisory:**
+  Use the **"Report a vulnerability"** button on the
+  [Security tab](https://github.com/angryip/ipscan/security) of this
+  repository. This keeps the report confidential until a fix is released
+  and allows GitHub to assign a CVE on request.
+
+  > **Note for maintainers:** If the "Report a vulnerability" button is not
+  > visible, enable **Private vulnerability reporting** under
+  > Settings → Code security and analysis.
+
+  **Alternative — Email:**
+  Contact the maintainer directly at `[maintainer email]` if the button
+  above is unavailable.
+
+
+  ## What to Include
+
+  - Description of the vulnerability and its potential impact
+  - Affected version(s)
+  - Steps to reproduce, or a proof-of-concept
+  - Suggested remediation (optional but welcome)
+
+
+  ## Response Timeline
+
+  | Milestone                   | Target  |
+  |-----------------------------|---------|
+  | Acknowledgement of receipt  | 14 days |
+  | Initial triage              | 30 days |
+  | Fix or remediation plan     | 90 days |
+
+  We follow a **90-day coordinated disclosure** window from the date of
+  acknowledgement. Please allow this time before publishing vulnerability
+  details publicly.
+
+  If no acknowledgement is received within 14 days, please follow up by
+  email or escalate to [MITRE](https://cveform.mitre.gov/).
+
+
+  ## Scope
+
+  - Vulnerabilities in Angry IP Scanner application code
+  - Security issues in exported file formats (SQL, XML, CSV) that cause harm
+    when the exported file is imported into a database or other tool
+  - Vulnerabilities in bundled third-party dependencies
+
+
+  ## Out of Scope
+
+  - Issues requiring physical access to the user's machine
+  - Vulnerabilities in operating system or JVM components not shipped with
+    the application


### PR DESCRIPTION
  ## What this PR adds

  A `SECURITY.md` file at the repository root, which:

  - Tells reporters which versions receive security fixes
  - Provides a clear, private channel for submitting vulnerability reports
  - Sets response time expectations (14-day acknowledgement, 90-day disclosure window)
  - Defines what is in and out of scope

  ## Why

  Without a `SECURITY.md`, security reporters have no official channel and
  may resort to opening public issues, which exposes vulnerability details
  before a fix is available.

  Once this file is merged, GitHub will display a **"Report a vulnerability"**
  button on the Security tab, giving reporters a confidential submission path
  directly to the maintainers.

  ## One follow-up step for maintainers

  After merging, please enable **Private vulnerability reporting** under:

  > Settings → Code security and analysis → Private vulnerability reporting → Enable

  This activates the "Report a vulnerability" button that the SECURITY.md
  references. Without this step the button will not appear.

  ## Notes

  - The `[maintainer email]` placeholder on line 22 should be replaced with
    a real contact address before or after merging
  - The supported versions table may need updating as new releases are made