### PR TITLE
Fix Gradle 9.x.x warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ String exec(def line, String dir = ".", boolean failOnError = true) {
 
 version = exec("git describe --tags", ".", false) ?: "unknown"
 
-sourceCompatibility = targetCompatibility = 17
+java.sourceCompatibility = java.targetCompatibility = 17
 
 def javaModules = ["java.base", "java.prefs", "java.logging", "jdk.crypto.ec"]
 project.ext.set("javaModules", javaModules)


### PR DESCRIPTION
Fix Gradle 9.x.x compatibility warnings.

Resolves https://github.com/angryip/ipscan/issues/516